### PR TITLE
updating csr name: intro section has a stale csr name

### DIFF
--- a/cfi_intro.adoc
+++ b/cfi_intro.adoc
@@ -148,10 +148,9 @@ only valid targets of an indirect jump (and not an indirect call).
 Forward-edge and backward-edge CFI may be enabled for a program that executes in
 U-mode, S-mode, or M-mode by itself to enable a mix of CFI enabled applications,
 operating systems, and machine mode firmware to co-exist.The processor keeps
-track of the CFI enables and CFI state for each mode in the `mcfistatus` CSR. A
-subset of the fields in the `mcfistatus` CSR are accessible using the
-`scfistatus` CSR. A VS-mode’s version of `scfistatus` is provided to track the
-CFI state for VS-mode and VU-mode.
+track of the CFI enables and CFI state for each mode in the `mstatus` CSR. A subset
+of the fields in the `mstatus` CSR are accessible using the `sstatus` CSR. VS-mode’s
+version of `sstatus` (`vsstatus`) tracks the CFI state for VS-mode and VU-mode.
 
 [NOTE]
 ====


### PR DESCRIPTION
xcfistatus dont exist anymore. cleaning up intro section with updated csr name.

Signed-off-by: Deepak Gupta <debug@rivosinc.com>