### PR TITLE
Mseccfg fix

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -518,7 +518,7 @@ The M-mode memory accesses by `sspop` instruction tests for read permission in
 the matching PMP entry when permission checking is required.
 
 When the `Smepmp` extension is implemented, a new WARL field `sspmp` is defined
-in bits 8:3 of the `mseccfg` CSR to configure a PMP entry as the shadow stack
+in bits 7:3 of the `mseccfg` CSR to select a PMP entry as the shadow stack
 memory region for M-mode accesses.
 
 When `mseccfg.MML` is 1, the `sspmp` field is read-only else it may be written.

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -518,7 +518,7 @@ The M-mode memory accesses by `sspop` instruction tests for read permission in
 the matching PMP entry when permission checking is required.
 
 When the `Smepmp` extension is implemented, a new WARL field `sspmp` is defined
-in bits 8:3 of the `mseccfg` CSR to configrue a PMP entry as the shadow stack
+in bits 8:3 of the `mseccfg` CSR to configure a PMP entry as the shadow stack
 memory region for M-mode accesses.
 
 When `mseccfg.MML` is 1, the `sspmp` field is read-only else it may be written.


### PR DESCRIPTION
b8:3 are actually 6 bits while only 5 bits are needed.
Furthermore b8 is already defined.

Note: Merge this after PR#21