### PR TITLE
Fix typos

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -430,7 +430,7 @@ enhanced to support a shadow stack memory region for use by M-mode.
 ==== Virtual-Memory system extension for Shadow Stack
 
 The shadow stack memory is protected using page table attributes such that it
-cannot be stored to by instructions other than `sspush` and `amossswap`. The
+cannot be stored to by instructions other than `sspush` and `ssamoswap`. The
 `sspop` instruction can only load from shadow stack memory.
 
 The shadow stack can be read using all instructions that load from memory. 
@@ -465,7 +465,7 @@ follows:
 
 5. A leaf PTE has been found. If the memory access is by a shadow stack
    instruction and `pte.xwr != 010b` then cause an access-violation exception
-   corresponding to the access type. If the memory acccess is a store/AMO and
+   corresponding to the access type. If the memory access is a store/AMO and
    `pte.xwr == 010b` then cause an store/AMO access-violation. If the requested
    memory access is not allowed by the `pte.r`, `pte.w`, `pte.x`, and `pte.u`
    bits, given the current privilege mode and the value of the `SUM` and `MXR`
@@ -518,13 +518,13 @@ The M-mode memory accesses by `sspop` instruction tests for read permission in
 the matching PMP entry when permission checking is required.
 
 When the `Smepmp` extension is implemented, a new WARL field `sspmp` is defined
-in bits 8:3 of the `mseccfg` CSR to configrue a PMP entry as the shadow stack
+in bits 8:3 of the `mseccfg` CSR to configure a PMP entry as the shadow stack
 memory region for M-mode accesses.
 
 When `mseccfg.MML` is 1, the `sspmp` field is read-only else it may be written.
 
 When `sspmp` field is implemented and `mseccfg.MML` is 1 the following rules are
-additionally enforcecd for M-mode memory accesses:
+additionally enforced for M-mode memory accesses:
 
 * `sspush`, `sspop`, and `ssamoswap` instructions must match PMP entry `sspmp`.
 

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -436,8 +436,8 @@ cannot be stored to by instructions other than `sspush` and `ssamoswap`. The
 The shadow stack can be read using all instructions that load from memory. 
 
 The encoding `R=0`, `W=1`, and `X=0`, is defined to mean a shadow stack page.
-When `menvcfg.CFI=0`, this encoding continues to be reserved. When `V=1` and 
-`henvcfg.CFI=0`, this encoding continues to be reserved at `VS` and `VU`.
+When `menvcfg.CFIE=0`, this encoding continues to be reserved. When `V=1` and 
+`henvcfg.CFIE=0`, this encoding continues to be reserved at `VS` and `VU`.
 
 The following faults may occur:
 
@@ -455,7 +455,7 @@ follows:
 3. If `pte.v = 0` or if any bits of encodings that are reserved for future
    standard use are set within `pte`, stop and raise a page-fault exception
    corresponding to the original access type. The encoding `pte.xwr = 010b`
-   is not reserved if `menvcfg.CFI` is 1 or if `V=1` and `henvcfg.CFI` is 1.
+   is not reserved if `menvcfg.CFIE` is 1 or if `V=1` and `henvcfg.CFIE` is 1.
    
 4. Otherwise, the PTE is valid. If `pte.r = 1` or `pte.w = 1` or `pte.x = 1`,
    go to step 5. Otherwise, this PTE is a pointer to the next level of the page

--- a/cfi_csrs.adoc
+++ b/cfi_csrs.adoc
@@ -37,7 +37,7 @@ separately enforced at S-mode and for each application.
 The `CFIE` (bit 60) bit controls if Zisslpcfi extension is available for use in
 VS and VU modes. When `menvcfg.CFIE` is 0, `henvcfg.CFIE` is read-only zero.
 
-When `henvcfg.CFI` bit is 0, then at privilege modes VS and VU:
+When `henvcfg.CFIE` bit is 0, then at privilege modes VS and VU:
 
 * Attempts to access `ssp` CSR and `lplr` CSR raise an illegal instruction
   exception.
@@ -63,8 +63,8 @@ The `xPELP` fields are encoded as follows:
 
 === Supervisor status registers (`sstatus`)
 
-When `menvcfg.CFI` is 1, access to the following fields accesses the homonymous
-field of `mstatus` register. When `menvcfg.CFI` is 0, these fields are read-only
+When `menvcfg.CFIE` is 1, access to the following fields accesses the homonymous
+field of `mstatus` register. When `menvcfg.CFIE` is 0, these fields are read-only
 zero.
 
 * `UFCFIE` (bit 23)
@@ -80,14 +80,14 @@ extension introduces the following fields.
 * `UBCFIE` (bit 24)
 * `SPELP` (bit 25)
 
-When `menvcfg.CFI` is 0, these fields are read-only zero. When `menvcfg.CFI` is
-1 and `henvcfg.CFI` is 0, these fields are read-only zero in `sstatus` (really
+When `menvcfg.CFIE` is 0, these fields are read-only zero. When `menvcfg.CFIE` is
+1 and `henvcfg.CFIE` is 0, these fields are read-only zero in `sstatus` (really
 `vsstatus`) when V=1.
 
 [NOTE]
 ====
 The `vsstatus` and `henvcfg` CSR for a virtual machine may be restored in any
-order. The state of `henvcfg.CFI` does not prevent access to the bits introduced
+order. The state of `henvcfg.CFIE` does not prevent access to the bits introduced
 in `vsstatus` when the CSR is accessed in HS-mode.
 ====
 
@@ -109,7 +109,7 @@ is split into a 8-bit upper label (`UL`), 8-bit middle label (`ML`), and a
 ], config:{lanes: 1, hspace:1024}}
 ....
 
-When `menvcfg.CFI` is 0, an attempt to access `lplr` in a mode other than M-mode
+When `menvcfg.CFIE` is 0, an attempt to access `lplr` in a mode other than M-mode
 raises an illegal instruction exception. When `sstatus.UFCFIE` is 0, an attempt
 to access `lplr` in U-mode raises an illegal instruction exception. 
 
@@ -121,10 +121,10 @@ U-mode `lplr` state even when the operating system itself does not enable the
 use of forward-edge CFI at S-mode.
 ====
 
-When `menvcfg.CFI` is 1 but `henvcfg.CFI` is 0, an attempt to access `lplr` when
+When `menvcfg.CFIE` is 1 but `henvcfg.CFIE` is 0, an attempt to access `lplr` when
 `V=1` raises a virtual instruction exception. 
 
-When `menvcfg.CFI` and `henvcfg.CFI` are both 1 but `vsstatus.UFCFIE` is 0, an
+When `menvcfg.CFIE` and `henvcfg.CFIE` are both 1 but `vsstatus.UFCFIE` is 0, an
 attempt to access `lplr` in VU-mode raises an illegal instruction exception.
 
 === Shadow stack pointer (`ssp`) 
@@ -133,7 +133,7 @@ The `ssp` CSR is an unprivileged read-write (URW) CSR that reads and writes `XLE
 low order bits of the shadow stack pointer (`ssp`). There is no high CSR defined
 as the `ssp` is always as wide as the `XLEN` of the current privilege level.
 
-When `menvcfg.CFI` is 0, an attempt to access `ssp` in a mode other than M-mode
+When `menvcfg.CFIE` is 0, an attempt to access `ssp` in a mode other than M-mode
 raises an illegal instruction exception. When `sstatus.UBCFIE` is 0, an attempt
 to access `ssp` in U-mode raises an illegal instruction exception.
 
@@ -143,10 +143,10 @@ Access to `ssp` at S-mode is not dependent on `sstatus.UBCFIE` to allow an
 operating system to be able to context switch U-mode `ssp` per application.
 ====
 
-When `menvcfg.CFI` is 1 but `henvcfg.CFI` is 0, an attempt to access `ssp` when
+When `menvcfg.CFIE` is 1 but `henvcfg.CFIE` is 0, an attempt to access `ssp` when
 `V=1` raises a virtual instruction exception. 
 
-When `menvcfg.CFI` and `henvcfg.CFI` are both 1 but `vsstatus.UBCFIE` is 0, an
+When `menvcfg.CFIE` and `henvcfg.CFIE` are both 1 but `vsstatus.UBCFIE` is 0, an
 attempt to access `ssp` in VU-mode raises an illegal instruction exception.
 
 === Machine Security Configuration (`mseccfg`)

--- a/cfi_csrs.adoc
+++ b/cfi_csrs.adoc
@@ -124,7 +124,7 @@ use of forward-edge CFI at S-mode.
 When `menvcfg.CFI` is 1 but `henvcfg.CFI` is 0, an attempt to access `lplr` when
 `V=1` raises a virtual instruction exception. 
 
-When `menvcfg.CFI` and `henvcfg.CFI` are both 1 but `vstatus.UFCFIE` is 0, an
+When `menvcfg.CFI` and `henvcfg.CFI` are both 1 but `vsstatus.UFCFIE` is 0, an
 attempt to access `lplr` in VU-mode raises an illegal instruction exception.
 
 === Shadow stack pointer (`ssp`) 

--- a/cfi_forward.adoc
+++ b/cfi_forward.adoc
@@ -4,7 +4,7 @@
 The forward-edge CFI introduces landing pad instructions that enable software to
 indicate valid targets for indirect calls and indirect jumps in a program. 
 
-A landing pad (`lpcul`) instruction is defined as the instruction that must be
+A landing pad (`lpcll`) instruction is defined as the instruction that must be
 placed at the program locations that can be valid targets of indirect jumps or
 calls. 
 
@@ -48,7 +48,7 @@ established in the `lplr` is matched with the target's label. If a mismatch is
 detected then the label check instruction causes an illegal instruction
 exception.
 
-Each landing pad may be labeled with a label that may be upto 25-bits wide. The
+Each landing pad may be labeled with a label that may be up to 25-bits wide. The
 `lplr` has three subfields - a 9-bit lower label (`LL`), a 8-bit middle label
 (`ML`), and an 8-bit upper label (`UL`).
 
@@ -224,7 +224,7 @@ endif
 [NOTE]
 ====
 The following instruction sequence may be emitted at indirect call sites by the
-compiler to set up the landing pad label register when labels that are upto
+compiler to set up the landing pad label register when labels that are up to
 9-bit wide are used:
 
 [literal]
@@ -261,7 +261,7 @@ endif
 [NOTE]
 ====
 The following instruction sequence may be emitted at indirect call sites by the
-compiler to set up the landing pad label register when labels that are upto
+compiler to set up the landing pad label register when labels that are up to
 17-bit wide are used:
 
 [literal]
@@ -300,7 +300,7 @@ endif
 [NOTE]
 ====
 The following instruction sequence may be emitted at indirect call sites by the
-compiler to set up the landing pad label register when labels that are upto
+compiler to set up the landing pad label register when labels that are up to
 25-bit wide are used:
 
 [literal]


### PR DESCRIPTION
*   General words
*   "upto" → "up to" (might be debatable)
*   `vstatus` → `vsstatus`
*   `amossswap` → `ssamoswap`

This is a superset of #21 and a partial superset of #24.

It causes a conflict with #26 (because I *just* fixed the spell).

I think the only debatable choice here is changing "upto" → "up to".  Other than that, it's pretty straight forward.