### PR TITLE
Extension: `Zimops` to `Zimop`

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -21,7 +21,7 @@ unsafe code sequences.
 
 The backward-edge CFI extension introduces the following instructions for shadow
 stack operations. All instructions are encoded using the SYSTEM major opcode and
-using the `mop.r` and `mop.rr` instructions defined by the Zimops extension.
+using the `mop.r` and `mop.rr` instructions defined by the Zimop extension.
 
 [width=100%]
 [%header, cols="6,<6,>6,<3,>3,<3,>3,<3,>3,<3,>3", grid=rows, frame=none]
@@ -84,7 +84,7 @@ else
 
 When backward-edge CFI is not enabled(`xBCFIE = 0`):
 
-* The instructions defined for backward-edge CFI revert to their Zimops defined
+* The instructions defined for backward-edge CFI revert to their Zimop defined
   behavior and write 0 to [rd].
 
 [NOTE]
@@ -93,7 +93,7 @@ The use of shadow stacks at U-mode must be explicitly enabled per application.
 Explicit enable for user mode applications allows such an application to invoke
 shared libraries that may have shadow stack instructions even when the
 application itself has backward-edge CFI not enable. The shadow stack
-instructions invoked in the context of this application revert to their Zimops
+instructions invoked in the context of this application revert to their Zimop
 defined behavior.
 
 When Zisslpcfi is enabled, the use of backward-edge CFI is always enabled for
@@ -111,15 +111,15 @@ compiled with shadow stack instructions.
 ====
 When programs using shadow stack instructions are installed on a machine that
 supports the CFI extensions but the operating system installed does not enable
-the CFI extensions, the program continues to function due to Zimops defined
+the CFI extensions, the program continues to function due to Zimop defined
 behavior of writing 0 to [rd] and not causing an illegal-instruction exception.
 
 When programs using shadow stack instructions are installed on a machine that
-does not support the CFI extensions but support the Zimops extension, the
-program continues to function due to Zimops defined behavior of writing 0 to
+does not support the CFI extensions but support the Zimop extension, the
+program continues to function due to Zimop defined behavior of writing 0 to
 [rd] and not causing an illegal-instruction exception.
 
-On machines that do not support Zimops extension, the instructions cause an
+On machines that do not support Zimop extension, the instructions cause an
 illegal-instruction exception. Installing programs that use the shadow stack
 instructions on such machines is not supported.
 ====
@@ -304,7 +304,7 @@ endif
 
 [NOTE]
 ====
-The property of Zimops writing 0 to the rd when the extension using Zimops is
+The property of Zimop writing 0 to the rd when the extension using Zimop is
 not present or not enabled may be used by such functions to skip over unwind
 actions by dynamically detecting if the backward-edge CFI extension is enabled.
 

--- a/cfi_csrs.adoc
+++ b/cfi_csrs.adoc
@@ -13,7 +13,7 @@ When `menvcfg.CFIE` bit is 0, then at privilege modes less privileged than M:
 
 * Attempts to access `ssp` CSR and `lplr` CSR raise an illegal instruction
   exception.
-* Zisslpcfi extension instructions revert to the Zimops defined behavior.
+* Zisslpcfi extension instructions revert to the Zimop defined behavior.
 * The `UBCFIE`, `UFCFIE` and `SPELP` fields in `mstatus` are read-only zero.
 * The `CFIE` field in `henvcfg` is read-only zero.
 * The `pte.xwr=010b` encoding in S-stage page tables is reserved.

--- a/cfi_forward.adoc
+++ b/cfi_forward.adoc
@@ -71,7 +71,7 @@ and on a mismatch causes an illegal-instruction exception.
 
 The forward-edge CFI introduces the following instructions for landing
 pad operations. All instructions are encoded using the SYSTEM major opcode and
-using the `mop.rr` instructions defined by the Zimops extension. 
+using the `mop.rr` instructions defined by the Zimop extension.
 
 [width=100%]
 [%header, cols="6,<2,>2,^2,^2,<3,>3,<3,>3,<3,>3,<3,>3", grid=rows, frame=none]
@@ -129,7 +129,7 @@ When forward-edge CFI is not active(`xFCFIE = 0`):
   indirect call or jump to be a landing pad instruction.
 * The implementation does not update expected landing pad (`ELP`) when `lpcll`
   is executed.
-* The instructions defined for forward-edge CFI revert to their Zimops defined
+* The instructions defined for forward-edge CFI revert to their Zimop defined
   behavior and write 0 to [rd].
 
 === Landing pad instruction

--- a/cfi_intro.adoc
+++ b/cfi_intro.adoc
@@ -165,10 +165,10 @@ on the program being executed in U-mode.
 
 To support backward compatibility of the programs built with Zisslpcfi support, the
 new instructions to operate on the shadow stack, the landing pad instructions,
-and the instructions to set the lplr are encoded using Zimops encodings. When
+and the instructions to set the lplr are encoded using Zimop encodings. When
 Zisslpcfi is not enabled for a program or the program is executing on a processor
 that does not support the Zisslpcfi extension then the instructions introduced by
-the Zisslpcfi extensions execute as defined by Zimops extension.
+the Zisslpcfi extensions execute as defined by Zimop extension.
 
 [NOTE]
 ====
@@ -178,19 +178,19 @@ extension. Such system libraries however may need to link dynamically to
 programs that are not compiled with the Zisslpcfi extension. When such programs are
 executing, the OS may disable the Zisslpcfi extension in U-mode. When these system
 libraries are invoked in U-mode by such programs, the Zisslpcfi instructions in the
-libraries revert to their Zimops defined behavior. Without such encoding, the OS
+libraries revert to their Zimop defined behavior. Without such encoding, the OS
 distribution may need to carry two versions of such libraries, one with Zisslpcfi
 instructions and one without, and thus need significantly larger cost and
 complexity for supporting the Zisslpcfi extension.
 
 An OS distribution compiled with Zisslpcfi extension may be installed on a machine
 that does not support Zisslpcfi extensions. On such machines, as the Zisslpcfi
-instructions are encoded as Zimops, they revert to their Zimops defined behavior.
+instructions are encoded as Zimop, they revert to their Zimop defined behavior.
 
 A program compiled with the Zisslpcfi extension may be installed on an OS that is
 not compiled for the Zisslpcfi extension or on a machine that does not support the
-Zisslpcfi extension. The Zisslpcfi instructions are encoded as Zimops revert back
-to their Zimops defined behavior.
+Zisslpcfi extension. The Zisslpcfi instructions are encoded as Zimop revert back
+to their Zimop defined behavior.
 ====
 
 The Zisslpcfi extension depends on the Zicsr extension.


### PR DESCRIPTION
According to the proposal documentation
<https://docs.google.com/spreadsheets/d/1SwjOz0xJBrbiwggh7MiwfWF5f-0zY9mjXYd51U0MJog/>, "May be ops" extension will be `Zimop`, not plural `Zimops`.

At first, @aswaterman notified me this fact (via private communication) just after I submitted the test patch to implement `Zisslpcfi` extension to GNU Binutils.

I know that it's now official, I'm now ready to submit this proposal.