### PR TITLE
sspmp: typo fix for sspmp entry

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -525,7 +525,7 @@ The M-mode memory accesses by `sspop` instruction tests for read permission in
 the matching PMP entry when permission checking is required.
 
 When the `Smepmp` extension is implemented, a new WARL field `sspmp` is defined
-in bits 8:3 of the `mseccfg` CSR to configure a PMP entry as the shadow stack
+in bits 15:10 of the `mseccfg` CSR to configure a PMP entry as the shadow stack
 memory region for M-mode accesses.
 
 When `mseccfg.MML` is 1, the `sspmp` field is read-only else it may be written.


### PR DESCRIPTION
bits 15:10 make up `sspmp`. fixing the typo