### PR TITLE
PR for issue 99

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -24,7 +24,7 @@ stack operations:
 * Push to and pop from the shadow stack (See <<SS_PUSH_POP>>)
 ** `sspush x1`, `c.sspush x1`, and `sspush x5`
 ** `sspopchk x1`, `sspopchk x5`, and `c.sspopchk x5`
-** `sspop x1` and `sspop x5`
+** `ssload x1` and `ssload x5`
 
 * Read the value of ssp into a register (See <<SSP_READ>>)
 ** `ssprr`
@@ -139,7 +139,7 @@ current top of the shadow stack followed by an increment of the `ssp` by
   {bits:  5, name: 'rd', attr:['00001','00101','00000','00000']},
   {bits:  3, name: 'funct3', attr:['100']},
   {bits:  5, name: 'rs1', attr:['00000','00000', '00001', '00101']},
-  {bits: 12, name: '100000011100', attr:['sspop  x1','sspop  x5','sspopchk x1','sspopchk x5']},
+  {bits: 12, name: '100000011100', attr:['ssload  x1','ssload  x5','sspopchk x1','sspopchk x5']},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
@@ -166,7 +166,7 @@ current top of the shadow stack followed by an increment of the `ssp` by
 ], config:{lanes: 1, hspace:1024}}
 ....
 
-Only `x1` and `x5` encodings are supported as `rd` for `sspop`.
+Only `x1` and `x5` encodings are supported as `rd` for `ssload`.
 Only `x1` and `x5` encodings are supported as `rs1` for `sspopchk`.
 Only `x1` and `x5` encodings are supported as `rs2` for `sspush`.
 
@@ -192,7 +192,7 @@ The `sspopchk` instruction and its compressed form `c.sspopchk` can be used to
 pop the shadow return address value from the shadow stack and check that the
 value matches the contents of the link register.
 
-The `sspop` instruction can be used to pop a return address from the shadow
+The `ssload` instruction can be used to load a return address from the shadow
 stack into a link register.
 
 While any register may be used as link register, conventionally the `x1` or `x5`
@@ -306,11 +306,12 @@ is as follows:
         #
          :
          :
-        sspop  x1      # pop return address from shadow stack
+        ssload  x1     # load return address from shadow stack
+        sspinc  $1     # increment ssp by XLEN/8
         #
-        # sspop loads the value from location addressed by ssp into
-        # destination register and updates ssp to (ssp + XLEN/8)
-        # - does a pop. Following completion of sspop the ssp value
+        # ssload loads the value from location addressed by ssp into
+        # destination register. sspinc updates ssp to (ssp + XLEN/8)
+        # - does a pop. Following completion of sspinc the ssp value
         # is the new top of stack i.e. 0x19740428
         #
         # 0x19740418:[          ]
@@ -329,7 +330,7 @@ be held in the link register itself for the duration of the leaf function
 execution.
 ====
 
-The `sspop`, `c.sspopchk`, and `sspopchk` instructions perform a load
+The `ssload`, `c.sspopchk`, and `sspopchk` instructions perform a load
 identically to the existing `LOAD` instruction, with the difference that the base
 is implicitly `ssp` and the width is implicitly `XLEN`.
 
@@ -337,16 +338,16 @@ The `sspush` and `c.sspush` instructions performs a store identically to the
 existing `STORE` instruction, with the difference that the base is implicitly
 `ssp` and the width is implicitly `XLEN`.
 
-The `sspush`, `c.sspush`, `sspopchk`, `c.sspopchk`, and `sspop` require the
+The `sspush`, `c.sspush`, `sspopchk`, `c.sspopchk`, and `ssload` require the
 virtual address in `ssp` to have a shadow stack attribute (see <<SSMP>>).
 
-Correct execution of `sspush`, `c.sspush`, `sspopchk`, `c.sspopchk`, and `sspop`
+Correct execution of `sspush`, `c.sspush`, `sspopchk`, `c.sspopchk`, and `ssload`
 require that `ssp` refers to idempotent memory. If the memory reference by the
 `ssp` is not idempotent, then the `sspush`/`c.sspush` instructions causes a
-store/AMO access-fault, and the `sspop`/`sspopchk`/`c.sspopchk` instructions
+store/AMO access-fault, and the `ssload`/`sspopchk`/`c.sspopchk` instructions
 cause a load access-fault.
 
-If the virtual address in `ssp` is not `XLEN` aligned, then the `sspop`/
+If the virtual address in `ssp` is not `XLEN` aligned, then the `ssload`/
 `sspopchk`/`c.sspopchk` instructions cause a load access-fault, and the `sspush`/
 `c.sspush` instructions cause a store/AMO access-fault.
 
@@ -386,15 +387,14 @@ else
 endif
 ----
 
-The operation of the `sspop` instruction is as follows:
+The operation of the `ssload` instruction is as follows:
 
-.`sspop` operation
+.`ssload` operation
 [source, ruby]
 ----
 if (xBCFIE = 1)
-    dst   = *[ssp]             # Load dst from address in ssp
+    [dst]   = *[ssp]           # Load dst from address in ssp
                                # Only x1 and x5 may be used as dst
-    [ssp] = [ssp] + (XLEN/8)   # Increment ssp by XLEN/8.
 else
     [dst] = 0;
 endif
@@ -420,7 +420,7 @@ else
 endif
 ----
 
-The `ssp` is incremented by `sspop`, `sspopchk`, and `c.sspopchk` only if the
+The `ssp` is incremented by `ssload`, `sspopchk`, and `c.sspopchk` only if the
 load from the shadow stack completes successfully. The `ssp` is decremented by
 `sspush` and `c.sspush` only if the store to the shadow stack completes
 successfully.
@@ -457,11 +457,11 @@ jump to the return address.
 ====
 Store-to-load forwarding is a common technique employed by high-performance
 processor implementations. CFI implementations may prevent forwarding from a
-non-shadow-stack store to `sspop`/`sspopchk`/`c.sspopchk` instructions. A
+non-shadow-stack store to `ssload`/`sspopchk`/`c.sspopchk` instructions. A
 non-shadow-stack store causes a fault if done to a page mapped as a shadow
 stack. However, such determination may be delayed till the PTE has been examined
 and thus may be used to transiently forward the data from such stores to a
-`sspop`/`sspopchk`/`c.sspopchk`.
+`ssload`/`sspopchk`/`c.sspopchk`.
 ====
 
 [NOTE]
@@ -505,8 +505,7 @@ longjmp() {
         // write the ssp register with unwound value
         asm("csrw %0, $ssp_csr_num" : "=r"(cur_ssp):);
         // Test if unwound past the shadow stack bounds
-        asm("sspush x5");
-        asm("sspop x5");
+        asm("ssload x5");
     }
 back_cfi_not_enabled:
     :
@@ -666,7 +665,7 @@ enhanced to support a shadow stack memory region for use by M-mode.
 
 The shadow stack memory is protected using page table attributes such that it
 cannot be stored to by instructions other than `sspush`, `c.sspush`, and
-`ssamoswap`. The `sspop`, `sspopchk`, and `c.sspopchk` instructions can only
+`ssamoswap`. The `ssload`, `sspopchk`, and `c.sspopchk` instructions can only
 load from shadow stack memory.
 
 The shadow stack can be read using all instructions that load from memory.
@@ -686,7 +685,7 @@ The following faults may occur:
 . If the accessed page is not a shadow stack page or if the page is in
   non-idempotent memory:
 .. `ssamoswap`, `c.sspush`, and `sspush` cause a store/AMO access-fault.
-.. `sspop`, `c.sspopchk`, and `sspopchk` cause a load access-fault.
+.. `ssload`, `c.sspopchk`, and `sspopchk` cause a load access-fault.
 
 [NOTE]
 ====
@@ -743,7 +742,7 @@ follows:
    fields of the `mstatus` register, stop and raise a page-fault exception
    corresponding to the original access type.
 
-The PMA checks are extended to require memory referenced by `sspush`, `sspop`,
+The PMA checks are extended to require memory referenced by `sspush`, `ssload`,
 `ssamoswap`, `c.sspush`, `c.sspopchk`, and `sspopchk` to be idempotent.
 
 The `U` and `SUM` bit enforcement is performed normally for shadow stack
@@ -773,7 +772,7 @@ an exception.
 ====
 
 The G-stage address translation and protections remain affected by the shadow
-stack extension. When G-stage page tables are active, the `ssamoswap`, `sspop`,
+stack extension. When G-stage page tables are active, the `ssamoswap`, `ssload`,
 `c.sspopchk`, and `sspopchk` instructions require the G-stage page table to have
 read permission for the accessed memory, whereas the `ssamoswap`, `c.sspush`, and
 `sspush` instructions require write permission. The `xwr == 010b` encoding in
@@ -799,13 +798,13 @@ profiling, and other use cases.
 
 When privilege mode is less than M, the PMP region accessed by `sspush`,
 `c.sspush`, and `ssamoswap` must provide write permission and the PMP region
-accessed by `sspop`, `c.sspopchk`, and `sspopchk` must provide read permission.
+accessed by `ssload`, `c.sspopchk`, and `sspopchk` must provide read permission.
 
 The M-mode memory accesses by `sspush`, `c.sspush` and `ssamoswap` instructions
 test for write permission in the matching PMP entry when permission checking is
 required.
 
-The M-mode memory accesses by `sspop`, `c.sspopchk`, and `sspopchk` instructions
+The M-mode memory accesses by `ssload`, `c.sspopchk`, and `sspopchk` instructions
 test for read permission in the matching PMP entry when permission checking is
 required.
 
@@ -817,7 +816,7 @@ When `mseccfg.MML` is 1, the `sspmp` field is read-only else it may be written.
 When the `sspmp` field is implemented, the following rules are additionally
 enforced for M-mode memory accesses:
 
-* `sspush`, `c.sspush`, `sspop`, `sspopchk`, `c.sspopchk`, and `ssamoswap`
+* `sspush`, `c.sspush`, `ssload`, `sspopchk`, `c.sspopchk`, and `ssamoswap`
   instructions must match PMP entry `sspmp`.
 
 * Write by instructions other than `sspush`, `c.sspush`, and `ssamoswap` that

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -25,6 +25,7 @@ stack operations:
 ** `sspush x1`, `c.sspush x1`, and `sspush x5`
 ** `sspopchk x1`, `sspopchk x5`, and `c.sspopchk x5`
 ** `ssload x1` and `ssload x5`
+** `sspinc`
 
 * Read the value of ssp into a register (See <<SSP_READ>>)
 ** `ssprr`
@@ -147,6 +148,17 @@ current top of the shadow stack followed by an increment of the `ssp` by
 ....
 {reg: [
   {bits:  7, name: 'opcode', attr:'SYSTEM'},
+  {bits:  5, name: '00000'},
+  {bits:  3, name: 'funct3', attr:['100']},
+  {bits:  5, name: 'nzuimm'},
+  {bits: 12, name: '100000011101', attr:['sspinc']},
+], config:{lanes: 1, hspace:1024}}
+....
+
+[wavedrom, , ]
+....
+{reg: [
+  {bits:  7, name: 'opcode', attr:'SYSTEM'},
   {bits:  5, name: 'rd', attr:['00000']},
   {bits:  3, name: 'funct3', attr:['100']},
   {bits:  5, name: 'rs1', attr:['00000']},
@@ -194,6 +206,10 @@ value matches the contents of the link register.
 
 The `ssload` instruction can be used to load a return address from the shadow
 stack into a link register.
+
+The `sspinc` instruction adds the zero-extended  non-zero immediate `nzuimm`,
+scaled by `XLEN/8`, to the `ssp`. This instruction may be used to pop from one
+to 31 return addresses from the shadow stack.
 
 While any register may be used as link register, conventionally the `x1` or `x5`
 registers are used. The shadow stack instructions are designed to be most
@@ -307,7 +323,7 @@ is as follows:
          :
          :
         ssload  x1     # load return address from shadow stack
-        sspinc  $1     # increment ssp by XLEN/8
+        sspinc  $1     # increment ssp by 1 * (XLEN/8)
         #
         # ssload loads the value from location addressed by ssp into
         # destination register. sspinc updates ssp to (ssp + XLEN/8)
@@ -395,6 +411,18 @@ The operation of the `ssload` instruction is as follows:
 if (xBCFIE = 1)
     [dst]   = *[ssp]           # Load dst from address in ssp
                                # Only x1 and x5 may be used as dst
+else
+    [dst] = 0;
+endif
+----
+
+The operation of the `sspinc` instruction is as follows:
+
+.`sspinc` operation
+[source, ruby]
+----
+if (xBCFIE = 1)
+    [ssp] = [ssp] + (nzuimm * XLEN/8)
 else
     [dst] = 0;
 endif

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -181,6 +181,7 @@ current top of the shadow stack followed by an increment of the `ssp` by
 Only `x1` and `x5` encodings are supported as `rd` for `ssload`.
 Only `x1` and `x5` encodings are supported as `rs1` for `sspopchk`.
 Only `x1` and `x5` encodings are supported as `rs2` for `sspush`.
+Only non-zero encodings of `nzuimm` are defined for `sspinc`.
 
 The extension includes 16-bit versions of the `sspush x1` and `sspopchk x5`
 instructions using the Zcmop encodings. The `c.sspush x1` and the

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -448,10 +448,9 @@ else
 endif
 ----
 
-The `ssp` is incremented by `ssload`, `sspopchk`, and `c.sspopchk` only if the
-load from the shadow stack completes successfully. The `ssp` is decremented by
-`sspush` and `c.sspush` only if the store to the shadow stack completes
-successfully.
+The `ssp` is incremented by `sspopchk` and `c.sspopchk` only if the load from
+the shadow stack completes successfully. The `ssp` is decremented by `sspush`
+and `c.sspush` only if the store to the shadow stack completes successfully.
 
 [NOTE]
 ====

--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -527,11 +527,26 @@ longjmp() {
     num_unwind = jmp_buf->saved_ssp - cur_ssp;
     // Unwind the frames in a loop
     while ( num_unwind > 0 ) {
-        step = ( num_unwind >= 4096 ) ? 4096 : num_unwind;
-        cur_ssp += step;
-        num_unwind -= step;
-        // write the ssp register with unwound value
-        asm("csrw %0, $ssp_csr_num" : "=r"(cur_ssp):);
+        if ( num_unwind >= 31 ) {
+            asm("sspinc $31");
+            num_unwind -= 31;
+            continue;
+        } else if ( num_unwind >= 16 ) {
+            asm("sspinc $16");
+            num_unwind -= 16;
+            continue;
+        } else if ( num_unwind >= 8 ) {
+            asm("sspinc $8");
+            num_unwind -= 8;
+            continue;
+        } else if ( num_unwind >= 4 ) {
+            asm("sspinc $4");
+            num_unwind -= 4;
+            continue;
+        } else {
+            asm("sspinc $1");
+            num_unwind -= 1;
+        }
         // Test if unwound past the shadow stack bounds
         asm("ssload x5");
     }

--- a/cfi_contributors.adoc
+++ b/cfi_contributors.adoc
@@ -3,4 +3,4 @@
 This RISC-V specification has been contributed to directly or indirectly by (in alphabetical order):
 
 [%hardbreaks]
-Adam Zabrocki, Andrew Waterman, Antoine Linarès, Dean Liberty, Deepak Gupta, Eckhard Delfs, George Christou, Greg McGary, Henry Hsieh, Johan Klockars, Kip Walker, Liu Zhiwei, Mark Hill, Nick Kossifidis, Sotiris Ioannidis, Thurston Dang, Tsukasa OI, Vedvyas Shanbhogue
+Adam Zabrocki, Andrew Waterman, Antoine Linarès, Dean Liberty, Deepak Gupta, Eckhard Delfs, George Christou, Greg McGary, Henry Hsieh, Johan Klockars, John Ingalls, Kip Walker, Liu Zhiwei, Mark Hill, Nick Kossifidis, Sotiris Ioannidis, Thurston Dang, Tsukasa OI, Vedvyas Shanbhogue

--- a/cfi_csrs.adoc
+++ b/cfi_csrs.adoc
@@ -285,7 +285,7 @@ When `menvcfg.CFIE` is 1 but `henvcfg.CFIE` is 0, an attempt to access `lpl` whe
 
 === Shadow stack pointer (`ssp`) 
 
-The `ssp` CSR is an supervisor read-write (SRW) CSR that reads and writes `XLEN`
+The `ssp` CSR is an unprivileged read-write (URW) CSR that reads and writes `XLEN`
 low order bits of the shadow stack pointer (`ssp`). There is no high CSR defined
 as the `ssp` is always as wide as the `XLEN` of the current privilege mode.
 

--- a/cfi_csrs.adoc
+++ b/cfi_csrs.adoc
@@ -285,7 +285,7 @@ When `menvcfg.CFIE` is 1 but `henvcfg.CFIE` is 0, an attempt to access `lpl` whe
 
 === Shadow stack pointer (`ssp`) 
 
-The `ssp` CSR is an unprivileged read-write (URW) CSR that reads and writes `XLEN`
+The `ssp` CSR is an supervisor read-write (SRW) CSR that reads and writes `XLEN`
 low order bits of the shadow stack pointer (`ssp`). There is no high CSR defined
 as the `ssp` is always as wide as the `XLEN` of the current privilege mode.
 


### PR DESCRIPTION
1. Drop `sspop` and redefine the code points presently defined for it as `ssload`
2. Introduce a `sspinc` instruction that increments `ssp` by a non-zero unsigned 5-bit immediate scaled by `XLEN/8`