### PR TITLE
Introduce integrity-fault exception

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -19,7 +19,9 @@ epilogue), the function loads the link register from the regular stack and
 the shadow copy of the link register from the shadow stack. The link register
 value from the regular stack and the shadow link register value from the shadow
 stack are compared. A mismatch of the two values is indicative of a subversion
-of the return address control variable and causes an illegal-instruction
+of the return address control variable and causes an integrity-fault exception
+with *tval set to "shadow stack fault (code=3)". The integrity-fault exception
+caused by the shadow stack fault is lower in priority than the load access fault
 exception.
 
 The Zicfiss extension introduces the following instructions:
@@ -179,7 +181,7 @@ a link register on the shadow stack.
 The `sspopchk` instruction and its compressed form `c.sspopchk` can be used to
 pop the shadow return address value from the shadow stack and check that the
 value matches the contents of the link register and if not cause an
-illegal-instruction exception.
+integrity-fault exception with *tval set to "shadow stack fault (code=3)".
 
 The `ssload` instruction can be used to load a return address from the shadow
 stack into a link register.
@@ -418,10 +420,10 @@ The operation of the `sspopchk` and `c.sspopchk` instructions is as follows:
 if (xBCFIE == 1)
     temp = mem[ssp]            # Load temp from address in ssp and
     if temp != X(src)          # Compare temp to value in src and
-                               # cause an illegal-instruction exception
+                               # cause an integrity-fault exception
                                # if they are not bitwise equal.
                                # Only x1 and x5 may be used as src
-       Raise illegal-instruction exception
+       Raise integrity-fault exception
     else
        ssp = ssp + (XLEN/8)    # increment ssp by XLEN/8.
     endif

--- a/cfi_forward.adoc
+++ b/cfi_forward.adoc
@@ -77,8 +77,9 @@ not need to establish an expected landing pad label value in `x7`.
 When `ELP` is set to `LP_EXPECTED`, if the next instruction in the instruction
 stream is not 4-byte aligned, or is not `lpad`, or if the landing pad label
 encoded in `lpad` is not zero and does not match the expected landing pad label
-in bits 31:12 of the `x7` register, then an illegal-instruction exception is
-raised else the `ELP` is updated to `NO_LP_EXPECTED`.
+in bits 31:12 of the `x7` register, then an integrity-fault exception with *tval
+set to "landing pad fault (code=2)" is raised else the `ELP` is updated to
+`NO_LP_EXPECTED`.
 
 [NOTE]
 ====
@@ -134,15 +135,16 @@ implemented or is not active.
 When Zicfilp is active, `lpad` is the only instruction allowed to execute when
 the `ELP` state is `LP_EXPECTED`. If Zicfilp is not active then the instruction
 is a no-op. If Zicfilp is active, the `lpad` instruction causes an
-illegal-instruction exception if any of the following conditions are true:
+integrity-fault exception with *tval set to "landing pad fault (code=2)" if any
+of the following conditions are true:
 
 * The `pc` is not 4-byte aligned.
 * The `ELP` is `LP_EXPECTED` and the `LPL` is not zero and the `LPL` does not
   match the expected landing pad label in bits 31:12 of the `x7` register.
 
-If the instruction causes an illegal-instruction exception, the `ELP` does not
-change. The behavior of the trap caused by this illegal-instruction exception is
-specified in section <<FORWARD_TRAPS>>. If an illegal-instruction exception is
+If the instruction causes an integrity-fault exception, the `ELP` does not
+change. The behavior of the trap caused by this integrity-fault exception is
+specified in section <<FORWARD_TRAPS>>. If an integrity-fault exception is
 not caused then the `ELP` is updated to `NO_LP_EXPECTED`.
 
 [wavedrom, ,svg]
@@ -160,12 +162,12 @@ The operation of the `lpad` instruction is as follows:
 [listing]
 ----
 if (xFCFIE != 0)
-    // If PC not 4-byte aligned then illegal-instruction
+    // If PC not 4-byte aligned then integrity-fault
     if pc[1:0] != 0
-        Cause illegal-instruction exception
-    // If landing pad label not matched -> illegal-instruction
+        Cause integrity-fault exception
+    // If landing pad label not matched -> integrity-fault
     else if (inst.LPL != x7[31:12] && inst.LPL != 0 && ELP == LP_EXPECTED)
-        Cause illegal-instruction exception
+        Cause integrity-fault exception
     else
         ELP = NO_LP_EXPECTED
 else
@@ -181,11 +183,15 @@ completion of `JALR`/`C.JALR`/`C.JR`, but before the instruction at the target
 of indirect call/jump was decoded, due to:
 
 * Asynchronous interrupts.
-* Synchronous exceptions with priority higher than that of an illegal-instruction
-  exception (See Table 3.7 of Privileged Specification cite:[PRIV]).
+* Synchronous exceptions with priority higher than that of an integrity-fault
+  exception with *tval set to "landing pad fault (code=2)" (See Table 3.7 of
+  Privileged Specification cite:[PRIV]).
 
-The illegal-instruction exception due to the instruction not being an `lpad`
-instruction when `ELP` is `LP_EXPECTED` or an illegal-instruction exception
+The integrity-fault exception caused by Zicfilp has higher priority than an
+illegal-instruction exception but lower priority than instruction access fault.
+
+The integrity-fault exception due to the instruction not being an `lpad`
+instruction when `ELP` is `LP_EXPECTED` or an integrity-fault exception
 caused by the `lpad` instruction itself (See <<LP_INST>>) leads to a trap being
 delivered to the same or to a higher privilege mode.
 

--- a/cfi_intro.adoc
+++ b/cfi_intro.adoc
@@ -140,7 +140,7 @@ using indirect call and jumps, and this is referred to as forward-edge
 protection. When the Zicfilp is active, the hart tracks an expected landing pad
 (`ELP`) state that is updated by an _indirect_call_ or _indirect_jump_ to
 require a landing pad instruction at the target of the branch. If the
-instruction at the target is not a landing pad, then an illegal-instruction
+instruction at the target is not a landing pad, then an integrity-fault
 exception is raised.
 
 A landing pad may be optionally associated with a 20-bit label. With labeling


### PR DESCRIPTION
The RISC-V Architecture Review Committee has discussed adding to
the forthcoming Privileged ISA version 1.13 exception cause codes for
synchronous exceptions due control flow integrity (CFI) checks, 
among other possible, related triggers. 
   cause code
    18 = integrity fault

On an integrity fault (code 18), the value automatically written to the
*tval CSR won't be an address but rather an additional numeric code:

   *tval
     2 = landing pad fault  (extension Zicfilp)
     3 = shadow stack fault (extension Zicfiss)
    others reserved