### PR TITLE
Editoral update

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -515,7 +515,7 @@ if (xSSE == 1)
                                # cause an software-check exception
                                # if they are not bitwise equal.
                                # Only x1 and x5 may be used as src
-       Raise software-check exception
+       raise software-check exception
     else
        ssp = ssp + (XLEN/8)    # increment ssp by XLEN/8.
     endif


### PR DESCRIPTION
I'm not sure whether capitalized `Raise` is acceptable in Sail code. However, the operations of `ssamoswap.w/d` are using non-capitalized `raise`. Therefore, I changed to make them consistent.