### PR TITLE
Fix typo

### DIFF
--- a/cfi_backward.adoc
+++ b/cfi_backward.adoc
@@ -832,7 +832,7 @@ instruction will result in a store/AMO access-fault exception.
 
 Memory mapped as an SS page cannot be written to by instructions other than
 `SSAMOSWAP.W/D`, `SSPUSH`, and `C.SSPUSH`. Attempts will raise a store/AMO
-page-fault exception. Implicit accesses, including instruction fetches to an SS
+access-fault exception. Implicit accesses, including instruction fetches to an SS
 page, are not permitted. Such accesses will raise an access-fault exception
 appropriate to the access type. However, the shadow stack is readable by all
 instructions that only load from memory.


### PR DESCRIPTION
Explanatory note below said writes of non-shadow-stack instructions will raise store/AMO access-fault exception, not store/AMO page-fault exception.