### PR TITLE
Clarify LPAD exceptions

### DIFF
--- a/cfi_forward.adoc
+++ b/cfi_forward.adoc
@@ -508,6 +508,7 @@ software-check exception with `__x__tval` set to "landing pad fault (code=2)" if
 any of the following conditions are true:
 
 * The `pc` is not 4-byte aligned and `ELP` is `LP_EXPECTED`.
+* The instruction is not `LPAD`.
 * The `ELP` is `LP_EXPECTED` and the `LPL` is not zero and the `LPL` does not
   match the expected landing pad label in bits 31:12 of the `x7` register.
 
@@ -532,10 +533,13 @@ The operation of the `LPAD` instruction is as follows:
 if (xLPE == 1 && ELP == LP_EXPECTED)
     // If PC not 4-byte aligned then software-check exception
     if pc[1:0] != 0
-        Cause software-check exception
+        raise software-check exception
+    // If instruction is not LPAD then software-check exception
+    else if (inst[6:0] != 23 || inst[11:7] != 0)
+        raise software-check exception
     // If landing pad label not matched -> software-check exception
     else if (inst.LPL != x7[31:12] && inst.LPL != 0)
-        Cause software-check exception
+        raise software-check exception
     else
         ELP = NO_LP_EXPECTED
 else


### PR DESCRIPTION
The spec said:
> When Zicfilp is enabled, `LPAD` is the only instruction allowed to execute when the `ELP` state is `LP_EXPECTED`.

It's expected that non-`LPAD` instructions will also raise the software-check exceptions. I added the descriptions in both the listings and the operations.