### PR TITLE
Fix table number of RAS hint

### DIFF
--- a/src/cfi_backward.adoc
+++ b/src/cfi_backward.adoc
@@ -429,7 +429,7 @@ instruction-fetch units, but they require accurate detection of instructions
 used for procedure calls and returns to be effective. For RISC-V, hints as to
 the instructions' usage are encoded implicitly via the register numbers used.
 The return-address stack (RAS) actions to pop and/or push onto the RAS are
-specified in Table 2.1 of the Unprivileged specification cite:[UNPRIV].
+specified in Table 3 of the Unprivileged specification cite:[UNPRIV].
 
 Using `x1` or `x5` as the link register allows a program to benefit from the
 return-address prediction stacks. Additionally, since the shadow stack

--- a/src/cfi_intro.adoc
+++ b/src/cfi_intro.adoc
@@ -28,7 +28,7 @@ convention that a `JAL`/`JALR` where `rd` (i.e. the link register) is `x1` or
 `x5` is a procedure call, and a `JALR` where `rs1` is the conventional
 link register (i.e. `x1` or `x5`) is a return from procedure. The architecture
 allows for using these hints and conventions to support return address
-prediction. The hints are specified in Table 2.1 of the Unprivileged ISA
+prediction. The hints are specified in Table 3 of the Unprivileged ISA
 specifications cite:[UNPRIV].
 
 The RVC standard extension for compressed instructions provides unconditional


### PR DESCRIPTION
In latest Unprivileged ISA specification, the table of RAS hint is numbered as Table 3.