### PR TITLE
Update cfi_intro.adoc: remove redundant 'rd == x0'

### DIFF
--- a/src/cfi_intro.adoc
+++ b/src/cfi_intro.adoc
@@ -48,7 +48,7 @@ register as destination, i.e., `rd != x0`. Conventionally, the link register is
 `C.JALR` is termed an _indirect-call_.
 
 The term _return_ is used to refer to a `JALR` instruction with `rd == x0` and
-with `rs1 == x1` or `rs1 == x5` and `rd == x0`. A `C.JR` instruction expands to
+with `rs1 == x1` or `rs1 == x5`. A `C.JR` instruction expands to
 `JALR x0, 0(rs1)` and is a _return_ if `rs1 == x1` or `rs1 == x5`.
 
 The term _indirect-jump_ is used to refer to a `JALR` instruction with `rd == x0`


### PR DESCRIPTION
Remove redundant 'rd == x0' in the definition of 'return'.